### PR TITLE
#165482850 Build out Activate or Deactivate account Endpoint (CRUD)

### DIFF
--- a/app/controllers/staffController.js
+++ b/app/controllers/staffController.js
@@ -137,5 +137,56 @@ export default class StaffController {
           message: 'you must be a staff (Cashier) to perform this task',
         });
     }
+
+    // Activate or Deactivate
+
+    static async ActivatOrDeactivateAccct(req, res) {
+      const user = auth.tokenBearer(req);
+      const { accountNumber } = req.params;
+  
+      if (user.isAdmin && user.type === 'staff') {
+        const getAccountQuery = 'SELECT * FROM  accounts WHERE accountNo = $1';
+        const editQuery = `UPDATE accounts SET status=$1 WHERE accountNo=$2 
+      RETURNING *`;
+  
+        const { status } = req.body;
+        const statusOptions = ['dormant', 'active'];
+        const values = [
+          status.trim(),
+          accountNumber,
+        ];
+        try {
+          const { rows } = await pool.query(getAccountQuery, [accountNumber]);
+          if (!rows[0]) {
+            return res.status(404).send({
+              status: 404,
+              error: 'Account does not exist',
+            });
+          }
+  
+          if (!statusOptions.includes(status)) {
+            return res.status(409).json({
+              status: 409,
+              error: 'Invalid account status field, status should be "dormant" or "active"',
+            });
+          }
+  
+          const response = await pool.query(editQuery, values);
+          return res.status(200).send({
+            status: 200,
+            data: response.rows[0],
+          });
+        } catch (error) {
+          return res.status(500).json({
+            status: status,
+            message: error.message,
+          });
+        }
+      }
+      return res.status(401).json({
+        status: 401,
+        message: 'you must be a staff (Admin) to perform this task',
+      });
+    }
 }
 


### PR DESCRIPTION
#### What does this PR do?

Implements Activate or Deactivate account functionality

#### Description of Task to be completed?

have this endpoint working
- PATCH /api/v1/accounts/:accountNumber

#### How should this be manually tested?

- Clone https://github.com/G-Chilie/Banka.git
-  On your terminal cd into the banka folder
-  Run npm install
-  Run npm run before:start
-  Run npm dev
-  On postman make a POST request to http://localhost:3000/api/v1/accounts/:accountNumber
NB see screenshot below on the request data to pass

#### What are the relevant pivotal tracker stories?

[#165482850
](https://www.pivotaltracker.com/story/show/165482850)

#### Screenshots (if appropriate)

![Activate-deactivate](https://user-images.githubusercontent.com/39604096/56555242-3a553400-658c-11e9-8ba9-203470937885.png)

